### PR TITLE
Make all Tiberium Rocks impassible

### DIFF
--- a/1.3/Defs/Buildings_Natural/Buildings_Natural_Rock.xml
+++ b/1.3/Defs/Buildings_Natural/Buildings_Natural_Rock.xml
@@ -19,6 +19,7 @@
 			</li>
 		</comps>
 		<altitudeLayer>Building</altitudeLayer>
+		<passability>Impassable</passability>
 		<blockWind>true</blockWind>
 		<castEdgeShadows>true</castEdgeShadows>
 		<fillPercent>1</fillPercent>


### PR DESCRIPTION
Tiberium Rocks can be created by Meteors or Tiberium Spreading into a natural Stone wall occasionally.

Untested. I have yet to set up my dev environment properly ;)

Resolves #11 